### PR TITLE
✨ Improve DSPy assertion behaviour

### DIFF
--- a/scripts/airflow2dagster/__main__.py
+++ b/scripts/airflow2dagster/__main__.py
@@ -1,14 +1,11 @@
-from functools import partial
 from pathlib import Path
 from typing import Optional
 
-import typer
-from dotenv import load_dotenv
-
 import dspy
-from airflow2dagster.model import Model
+import typer
+from airflow2dagster.model import get_translator
 from airflow2dagster.utils import configure_dspy
-from dspy.primitives.assertions import backtrack_handler
+from dotenv import load_dotenv
 
 load_dotenv()
 configure_dspy()
@@ -16,17 +13,8 @@ configure_dspy()
 app = typer.Typer()
 
 
-def _get_translator(retries: int | None) -> Model:
-    model = Model()
-    if retries:
-        model = model.activate_assertions(
-            partial(backtrack_handler, max_backtracks=retries)
-        )
-    return model
-
-
 def translate_airflow_code(airflow_code: str, retries: int | None) -> str:
-    translator = _get_translator(retries=retries)
+    translator = get_translator(retries=retries)
     return translator(airflow_code).dagster_code
 
 

--- a/scripts/airflow2dagster/model.py
+++ b/scripts/airflow2dagster/model.py
@@ -36,6 +36,7 @@ def get_translator(retries: int | None) -> Model:
     model = Model()
     if retries:
         for name, submodule in model.named_sub_modules():
+            # Do not wrap main module with assertions, as it'll encounter a deadlock
             if name == "self":
                 continue
             submodule.activate_assertions(

--- a/scripts/airflow2dagster/model.py
+++ b/scripts/airflow2dagster/model.py
@@ -30,3 +30,15 @@ class Model(dspy.Module):
         )
 
         return dspy.Prediction(dagster_code=pred.dagster_code)
+
+
+def get_translator(retries: int | None) -> Model:
+    model = Model()
+    if retries:
+        for name, submodule in model.named_sub_modules():
+            if name == "self":
+                continue
+            submodule.activate_assertions(
+                partial(backtrack_handler, max_backtracks=retries)
+            )
+    return model


### PR DESCRIPTION
DSPy has been observed to fail on certain cases, despite an excessive retry budget. 

This is because the default way the library implements retries is to always retry from the start of the main module, instead of just the failing submodule. As a result, all upstream submodules have to be re-run and their associated historical failures re-triggered, eating into the retry budget in a quadratic fashion.

Illustration:
```
# First attempt 
Module
  - Submodule1  <-- Fail
  - Submodule2

# Second attempt 
Module
  - Submodule1  <-- Pass (w/ feedback from previous failure)
  - Submodule2  <-- Fail

# Third attempt (repeat of First Attempt)
Module
  - Submodule1  <-- Fail
  - Submodule2

# Fourth attempt 
Module
  - Submodule1  <-- Pass (w/ feedback from First Attempt's failure)
  - Submodule2  <-- Pass (w/ feedback from Second Attempt's failure)
 ```

With this modified implementation, a failure at a submodule will be retried just at the failing submodule. 