### PR TITLE
draft: making dependencies betweens assets

### DIFF
--- a/scripts/airflow2dagster/add_dependencies.py
+++ b/scripts/airflow2dagster/add_dependencies.py
@@ -1,0 +1,57 @@
+import dspy
+from airflow2dagster.utils import extract_code_block_from_markdown
+from metrics.run_validity import is_runnable
+
+relevant_documentation = """
+### 
+```
+Requirements:
+    - Asset functions should manage reading and writing data themselves, such as reading from a file to disk or writing to a database
+    - Use the `@asset` decorator's `deps` argument to specify dependencies
+    - Pass the dependencies as a list of asset-decorated functions
+    - Out of convention, avoid using IO managers
+    - Do not use `ins` and `outs` arguments, and thus, don't use AssetIn or AssetOut
+    - Do not pass the dependencies as arguments to the decorated function
+```
+"""
+
+
+class AddDependenciesSignature(dspy.Signature):
+    """
+    Surface relevant metadata using `MaterializeResult` instead of `AssetMaterialization`.
+
+    Ensure that metadata fields are added using `MetadataValue`.
+    """
+
+    context = dspy.InputField(desc="Potentially relevant Dagster documentation")
+    input_dagster_code = dspy.InputField()
+    dagster_code = dspy.OutputField(
+        desc="Dagster code with `MaterializeResult` surfacing asset metadata where relevant"
+    )
+
+
+class AddDependenciesModule(dspy.Module):
+    def __init__(self):
+        self.retrieve = dspy.Retrieve(k=3)
+        self.add_dependencies = dspy.ChainOfThought(
+            AddDependenciesSignature
+        )
+
+    def forward(self, input_dagster_code: str) -> dspy.Prediction:
+        # context = self.retrieve(self.add_dependencies.signature.__doc__).passages
+        context = [relevant_documentation]
+        pred = self.add_dependencies(
+            context="\n".join(context), input_dagster_code=input_dagster_code
+        )
+        pred.dagster_code = extract_code_block_from_markdown(pred.dagster_code)
+
+        dspy.Assert(
+            "@asset" in pred.dagster_code,
+            "Do not forget to include the input Dagster code in the final code.",
+        )
+
+        dspy.Suggest(
+            *is_runnable(pred.dagster_code, verbose=True)
+        )  # Some code cannot be run without external dependencies
+
+        return dspy.Prediction(dagster_code=pred.dagster_code)

--- a/scripts/airflow2dagster/model.py
+++ b/scripts/airflow2dagster/model.py
@@ -9,6 +9,7 @@ from airflow2dagster.add_materialization_results import AddMaterializationResult
 from airflow2dagster.add_retry_policy import AddRetryPolicyModule
 from airflow2dagster.add_schedule import AddScheduleModule
 from airflow2dagster.translate_core_logic import TranslateCoreLogicModule
+from airflow2dagster.add_dependencies import AddDependenciesModule
 from airflow2dagster.utils import format_code
 from dspy.primitives.assertions import backtrack_handler
 
@@ -16,6 +17,7 @@ from dspy.primitives.assertions import backtrack_handler
 class Model(dspy.Module):
     def __init__(self):
         self.translate_core_logic = TranslateCoreLogicModule()
+        self.add_dependencies = AddDependenciesModule()
         self.add_materialization_result = AddMaterializationResultModule()
         self.add_config = AddConfigModule()
         self.add_definitions = AddDefinitionsModule()
@@ -25,6 +27,7 @@ class Model(dspy.Module):
 
     def forward(self, airflow_code: str) -> dspy.Prediction:
         pred = self.translate_core_logic(airflow_code)
+        pred = self.add_dependencies(pred.dagster_code)
         pred = self.add_materialization_result(pred.dagster_code)
 
         # NOTE: From experiments, configs should be generated *after* materialization results.


### PR DESCRIPTION
I've noticed that dependencies between assets are a bit flaky and use a varying number of APIs, so I'm introducing a new module to focus on just one core API and force it to make dependencies.

Given the lack of complexity of the current scope of examples, I think it's better if we avoid using IO managers and advocate more for having the assets managing reading and writing data themselves, so I defer to use the `deps` argument to make dependencies.

I'm a scrub and don't know how any of this leaderboard or `generate_cli` stuff works, so I'll raise this tentatively and we'll chat through this live during our weekly call.